### PR TITLE
due to replacing ssh to mount package management, base url has change…

### DIFF
--- a/resources/username.repo
+++ b/resources/username.repo
@@ -1,13 +1,13 @@
 [{{USERNAME}}-devel]
 name={{USERNAME}} repository devel
-baseurl=http://rbrepo.redborder.lan/ng/devel/{{USERNAME}}/rhel/9/x86_64/
+baseurl=https://packages.redborder.com/devel/{{USERNAME}}/rhel/9/x86_64/
 gpgcheck=0
 enabled=1
 sslcheck=0
 
 [{{USERNAME}}-devel-source]
 name={{USERNAME}} repository devel
-baseurl=http://rbrepo.redborder.lan/ng/devel/{{USERNAME}}/rhel/9/SRPMS/
+baseurl=https://packages.redborder.com/devel/{{USERNAME}}/rhel/9/SRPMS/
 gpgcheck=0
 enabled=0
 sslcheck=0


### PR DESCRIPTION
From this point we start to consider packaging to a different server. Untili now we were using rbrepo, but now we are going to use packages.redborder.com for ng